### PR TITLE
Add breadcrumbs to navbar and show Vessel tab options in navbar

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,6 +3,7 @@ import { RouterView, useRouter } from 'vue-router'
 import AuthenticationIndicator from './components/user/AuthenticationIndicator.vue';
 import { useUser } from './composables/auth/useUser';
 import { useRssOAuth } from './composables/auth/rss-oauth/useRssOAuth';
+import { provide, ref } from 'vue';
 
 const router = useRouter()
 
@@ -41,22 +42,85 @@ const _ = useRssOAuth()
 
 trySilentLogin()
 
+interface NavbarBreadcrumbItem {
+  show: boolean
+  loading: boolean
+  title: string
+  link?: string
+}
+
+const navbarTabs = ref<Array<{ label: string, value: string }>>([])
+const currentNavbarTab = ref<string>('')
+
+const navbarBreadcrumbs = ref<Array<NavbarBreadcrumbItem>>([{
+  show: true,
+  loading: false,
+  title: 'Vessels',
+  link: ''
+}])
+
+provide('navbar', {
+  tabs: navbarTabs,
+  breadcrumbs: navbarBreadcrumbs,
+  currentTab: currentNavbarTab,
+  setTabs: (tabs: Array<{ label: string, value: string }>) => {
+    navbarTabs.value = tabs
+  },
+  setCurrentTab: (tabValue: string) => {
+    currentNavbarTab.value = tabValue
+  },
+  clearTabs: () => {
+    navbarTabs.value = []
+    currentNavbarTab.value = ''
+  },
+  setBreadcrumbs: (breadcrumbs: Array<NavbarBreadcrumbItem>) => {
+    navbarBreadcrumbs.value = breadcrumbs
+  },
+  clearBreadcrumbs: () => {
+    navbarBreadcrumbs.value = [{
+      show: true,
+      loading: false,
+      title: 'Vessels',
+      link: ''
+    }]
+  },
+})
+
 </script>
 
 <template>
   <v-layout>
     <v-app-bar density="compact">
       <template v-slot:prepend>
-        <v-btn @click="router.push('/')">Home</v-btn>
+        <v-breadcrumbs v-if="navbarBreadcrumbs.length > 0" :items="navbarBreadcrumbs" density="compact" class="pa-0">
+          <template v-slot:title="{ item }">
+            <v-skeleton-loader v-if="item.loading" type="button"></v-skeleton-loader>
+            <span v-else-if="item.link && item.link !== ''" @click="router.push(item.link)" class="breadcrumb-link">
+              {{ item.title }}
+            </span>
+            <span v-else>{{ item.title }}</span>
+          </template>
+
+          <template v-slot:divider>
+            <v-icon size="small">mdi-chevron-right</v-icon>
+          </template>
+        </v-breadcrumbs>
+
+
       </template>
 
       <template v-slot:append>
+        <v-tabs v-if="navbarTabs.length > 0" v-model="currentNavbarTab" bg-color="transparent">
+          <v-tab v-for="tab in navbarTabs" :key="tab.value" :value="tab.value">
+            {{ tab.label }}</v-tab>
+        </v-tabs>
+        <v-divider class="mx-3" vertical></v-divider>
         <AuthenticationIndicator></AuthenticationIndicator>
       </template>
     </v-app-bar>
 
     <v-main class="fill-height">
-        <RouterView />
+      <RouterView />
     </v-main>
   </v-layout>
 </template>

--- a/src/components/user/AuthenticationIndicator.vue
+++ b/src/components/user/AuthenticationIndicator.vue
@@ -37,7 +37,7 @@ function register() {
                         v-bind="props" 
                         variant="flat"
                         class="rounded"
-                        color="primary"
+                        color=""
                         block="false">
                         <v-icon>mdi-account</v-icon>
                     </v-btn>


### PR DESCRIPTION
Vessel details page and flight details page now has breadcrumbs to go back to the vessels list or the vessel selected.

The vessels details page has the tab selector moved into navbar. Makes UI bit less clunky and will help with the layout to show live flights straight away on the vessel page.

<img width="802" height="238" alt="Screenshot 2025-08-21 at 17 37 54" src="https://github.com/user-attachments/assets/6291e100-02d7-4ac0-97cc-a72e7c44a8bc" />



<img width="806" height="469" alt="Screenshot 2025-08-21 at 17 38 03" src="https://github.com/user-attachments/assets/43024c40-8711-49f5-bad8-fc0a8d65dd53" />
